### PR TITLE
Tournament teams

### DIFF
--- a/app/controllers/api/v0/teams_controller.rb
+++ b/app/controllers/api/v0/teams_controller.rb
@@ -1,0 +1,9 @@
+class Api::V0::TeamsController < ApplicationController
+  def index
+    tournament = Tournament.find_by(id: params[:tournament_id])
+    teams = tournament.teams
+    options = {}
+    options[:include] = [:players]
+    rendor json: TeamSerializer.new(teams, options)
+  end
+end

--- a/app/controllers/api/v0/teams_controller.rb
+++ b/app/controllers/api/v0/teams_controller.rb
@@ -4,6 +4,6 @@ class Api::V0::TeamsController < ApplicationController
     teams = tournament.teams
     options = {}
     options[:include] = [:players]
-    rendor json: TeamSerializer.new(teams, options)
+    render json: TeamSerializer.new(teams, options)
   end
 end

--- a/app/serializers/player_serializer.rb
+++ b/app/serializers/player_serializer.rb
@@ -1,0 +1,13 @@
+class PlayerSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type 'players'
+  attributes :first_name,
+             :last_name,
+             :height,
+             :weight,
+             :birthday,
+             :graduation_year,
+             :position,
+             :recruit
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,15 @@ Rails.application.routes.draw do
     namespace :v0 do
       # resource :users, only: [:create]
       # post "/login", to: "users#login"
-      # resources :tournaments
-      get "/tournaments", to: "tournaments#index"
-      get "/tournaments/:id", to: "tournaments#show"
+      resources :tournaments, only: [:index, :show] do
+        resources :teams, only: [:index]
+      end
+      # story #4
+      # api/v0/players/id/assessments
+      # resources :players do
+      #   #assessment controller
+      #   resources :assessments, only: [:index]
+      # end
     end
   end
 end

--- a/spec/requests/api/v0/teams_request_spec.rb
+++ b/spec/requests/api/v0/teams_request_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe 'Teams API' do
+  describe 'Happy Path' do
+    it "returns all teams for a single tournament, with optionally included team rosters" do
+      tournament = Tournament.create!(name: "The Orange Classic", city: "Orlando", state: "FL", start_date: "2021-09-05")
+      team1 = Team.create!(name: "Orlando Blaze", age_group: "N/A")
+      team2 = Team.create!(name: "Ohio All Stars", age_group: "N/A")
+      team3 = Team.create!(name: "Mile High Magic", age_group: "N/A")
+      tournament_team1 = TournamentTeam.create!(tournament: tournament, team: team1)
+      tournament_team2 = TournamentTeam.create!(tournament: tournament, team: team2)
+      tournament_team2 = TournamentTeam.create!(tournament: tournament, team: team3)
+      player1 = Player.create!(first_name: "Tim", last_name: "Smith", height: 72, weight: 188, birthday: "2006-02-23", graduation_year: 2024, position: "Shooting Guard", recruit: true, team: team1)
+      player2 = Player.create!(first_name: "Dan", last_name: "Holland", height: 75, weight: 201, birthday: "2005-02-23", graduation_year: 2023, position: "Center", recruit: true, team: team2)
+      player3 = Player.create!(first_name: "Scott", last_name: "Thompson", height: 70, weight: 175, birthday: "2007-02-23", graduation_year: 2025, position: "Point Guard", recruit: true, team: team3)
+      player4 = Player.create!(first_name: "Omar", last_name: "Brown", height: 71, weight: 182, birthday: "2006-07-23", graduation_year: 2024, position: "Shooting Guard", recruit: true, team: team1)
+      player5 = Player.create!(first_name: "Olaf", last_name: "Schliner", height: 73, weight: 190, birthday: "2007-04-23", graduation_year: 2025, position: "Forward", recruit: true, team: team2)
+
+      headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      }
+
+      request_body = {
+        'tournaments': tournament.id,
+        'teams': [team1, team2, team3],
+        'players': [player1, player2, player3, player4, player5]
+      }
+
+      get "/api/v0/tournaments/#{tournament.id}/teams?included=players"
+
+      teams = JSON.parse(response.body, symbolize_names: true)
+      require "pry"; binding.pry
+    end
+  end
+end

--- a/spec/requests/api/v0/teams_request_spec.rb
+++ b/spec/requests/api/v0/teams_request_spec.rb
@@ -5,16 +5,9 @@ describe 'Teams API' do
     it "returns all teams for a single tournament, with optionally included team rosters" do
       tournament = Tournament.create!(name: "The Orange Classic", city: "Orlando", state: "FL", start_date: "2021-09-05")
       team1 = Team.create!(name: "Orlando Blaze", age_group: "N/A")
-      team2 = Team.create!(name: "Ohio All Stars", age_group: "N/A")
-      team3 = Team.create!(name: "Mile High Magic", age_group: "N/A")
       tournament_team1 = TournamentTeam.create!(tournament: tournament, team: team1)
-      tournament_team2 = TournamentTeam.create!(tournament: tournament, team: team2)
-      tournament_team2 = TournamentTeam.create!(tournament: tournament, team: team3)
       player1 = Player.create!(first_name: "Tim", last_name: "Smith", height: 72, weight: 188, birthday: "2006-02-23", graduation_year: 2024, position: "Shooting Guard", recruit: true, team: team1)
-      player2 = Player.create!(first_name: "Dan", last_name: "Holland", height: 75, weight: 201, birthday: "2005-02-23", graduation_year: 2023, position: "Center", recruit: true, team: team2)
-      player3 = Player.create!(first_name: "Scott", last_name: "Thompson", height: 70, weight: 175, birthday: "2007-02-23", graduation_year: 2025, position: "Point Guard", recruit: true, team: team3)
       player4 = Player.create!(first_name: "Omar", last_name: "Brown", height: 71, weight: 182, birthday: "2006-07-23", graduation_year: 2024, position: "Shooting Guard", recruit: true, team: team1)
-      player5 = Player.create!(first_name: "Olaf", last_name: "Schliner", height: 73, weight: 190, birthday: "2007-04-23", graduation_year: 2025, position: "Forward", recruit: true, team: team2)
 
       headers = {
         'Content-Type': 'application/json',
@@ -23,14 +16,69 @@ describe 'Teams API' do
 
       request_body = {
         'tournaments': tournament.id,
-        'teams': [team1, team2, team3],
-        'players': [player1, player2, player3, player4, player5]
+        'teams': [team1],
+        'players': [player1, player4]
       }
 
       get "/api/v0/tournaments/#{tournament.id}/teams?included=players"
-
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
       teams = JSON.parse(response.body, symbolize_names: true)
-      require "pry"; binding.pry
+      expect(teams).to be_a(Hash)
+      expect(teams).to have_key(:data)
+      expect(teams[:data]).to be_an(Array)
+      team_info = teams[:data][0]
+      expect(team_info).to be_a(Hash)
+      expect(team_info).to have_key(:id)
+      expect(team_info[:id]).to be_a(String)
+      expect(team_info).to have_key(:type)
+      expect(team_info[:type]).to be_a(String)
+      expect(team_info).to have_key(:attributes)
+      team_attr = team_info[:attributes]
+      expect(team_attr).to be_a(Hash)
+      expect(team_attr).to have_key(:name)
+      expect(team_attr[:name]).to be_a(String)
+      expect(team_attr).to have_key(:age_group)
+      expect(team_attr[:age_group]).to be_a(String)
+      expect(team_info).to have_key(:relationships)
+      team_relationships = team_info[:relationships]
+      expect(team_relationships).to be_a(Hash)
+      expect(team_relationships).to have_key(:players)
+      expect(team_relationships[:players]).to be_a(Hash)
+      expect(team_relationships[:players]).to have_key(:data)
+      expect(team_relationships[:players][:data]).to be_an(Array)
+      expect(team_relationships[:players][:data].count).to eq(2)
+      expect(team_relationships[:players][:data][0]).to have_key(:id)
+      expect(team_relationships[:players][:data][0][:id]).to be_a(String)
+      expect(team_relationships[:players][:data][0]).to have_key(:type)
+      expect(team_relationships[:players][:data][0][:type]).to be_a(String)
+      expect(teams).to have_key(:included)
+      expect(teams[:included]).to be_an(Array)
+      expect(teams[:included].count).to eq(2)
+      team_roster = teams[:included][0]
+      expect(team_roster).to have_key(:id)
+      expect(team_roster[:id]).to be_a(String)
+      expect(team_roster).to have_key(:type)
+      expect(team_roster[:type]).to be_a(String)
+      expect(team_roster).to have_key(:attributes)
+      expect(team_roster[:attributes]).to be_a(Hash)
+      player_attr = team_roster[:attributes]
+      expect(player_attr).to have_key(:first_name)
+      expect(player_attr[:first_name]).to be_a(String)
+      expect(player_attr).to have_key(:last_name)
+      expect(player_attr[:last_name]).to be_a(String)
+      expect(player_attr).to have_key(:height)
+      expect(player_attr[:height]).to be_an(Integer)
+      expect(player_attr).to have_key(:weight)
+      expect(player_attr[:weight]).to be_an(Integer)
+      expect(player_attr).to have_key(:birthday)
+      expect(player_attr[:birthday]).to be_a(String)
+      expect(player_attr).to have_key(:graduation_year)
+      expect(player_attr[:graduation_year]).to be_an(Integer)
+      expect(player_attr).to have_key(:position)
+      expect(player_attr[:position]).to be_a(String)
+      expect(player_attr).to have_key(:recruit)
+      expect(player_attr[:recruit]).to be_a(TrueClass)
     end
   end
 end

--- a/spec/requests/api/v0/tournaments_request_spec.rb
+++ b/spec/requests/api/v0/tournaments_request_spec.rb
@@ -102,7 +102,6 @@ describe 'Tournaments API' do
     expect(response).to be_successful
     expect(response.status).to eq(200)
     tournament = JSON.parse(response.body, symbolize_names: true)
-    # require "pry"; binding.pry
     expect(tournament).to be_a(Hash)
     expect(tournament).to have_key(:data)
     expect(tournament[:data]).to be_a(Hash)


### PR DESCRIPTION
# This PR includes the following for drilling down into the teams of each tournament and viewing the players for that team:

## Routes:
- [x] nest resources :teams, only: [:index] within resources :tournaments

## Controllers:
- [x] teams_controller (Api::V0::TeamsController < ApplicationController)
- [x] index action that:
  - finds team by id
  - get teams by tournament
  - sets an option to include :players
  - renders TeamSerializer.new(teams, options)

## Serializers
- [x] team_serializer with:
  - attributes
  - relationship has_many :players 

## Request Test
- [x] teams_request_spec.rb